### PR TITLE
Broken Windows Search Per User Search

### DIFF
--- a/FSLogix/FSLogix-UPMToProfileContainer.ps1
+++ b/FSLogix/FSLogix-UPMToProfileContainer.ps1
@@ -110,6 +110,10 @@ $urigpathpermission2 = Get-Acl -Path $urigpathper2
 Set-Acl -AclObject $urigpathpermission2 -Path 'Y:\Profile'
 dir -r 'Y:\Profile' | Set-Acl -AclObject $urigpathpermission2#>
 
+#Remove Windows Search Folder, to repair Windows Per User Search. Windows Search Folder is created automaticly and works after restart of Windows Search Service
+if (Test-Path "Y:\Profile\AppData\Roaming\Microsoft\Search") {
+  Remove-Item -Path "Y:\Profile\AppData\Roaming\Microsoft\Search" -Force -Recurse | Out-Null
+  }
 
 if (!(Test-Path "Y:\Profile\AppData\Local\FSLogix")) {
 New-Item -Path "Y:\Profile\AppData\Local\FSLogix" -ItemType directory | Out-Null


### PR DESCRIPTION
### Problem:
After migrating to FSLogix, users reported that the search functionality no longer works. Upon inspecting the user profiles, it was found that the permissions for the Search folder under `C:\Users\%Username%\AppData\Roaming\Microsoft\` are incorrect.

### Workaround for Migrated Profiles:
1. Log off the user.
2. Mount the user's VHD/VHDX disk.
3. Delete the folder `C:\Users\%Username%\AppData\Roaming\Microsoft\Search\`.
4. Log the user back in.
5. Restart the Windows Search Service or wait for other users to trigger it via the task configured as per the instructions on [jkindon.com](https://jkindon.com/windows-search-in-server-2019-and-multi-session-windows-10/).

### Workaround for Profiles Not Yet Migrated:
Delete the folder `C:\Users\%Username%\AppData\Roaming\Microsoft\Search\` during migration before the user logs in for the first time.

### Result:
Outlook search and indexing functionality restored.

![image](https://github.com/user-attachments/assets/3e96e4bd-1eef-492b-a519-3c179562ee76)
